### PR TITLE
Add task history to home screen

### DIFF
--- a/app/src/main/java/com/example/client_volcal_baseline/MainActivity.kt
+++ b/app/src/main/java/com/example/client_volcal_baseline/MainActivity.kt
@@ -37,9 +37,11 @@ private fun AppNavRoot() {
         composable("upload") {
             // 直接把 Activity 作为 context 传给 ViewModel（简单起步）
             val vm: UploadViewModel = viewModel(factory = UploadViewModel.provideFactory(LocalContext.current))
-            UploadScreen(vm) { taskId ->
-                nav.navigate("status/$taskId")
-            }
+            UploadScreen(
+                vm,
+                onNavigate = { taskId -> nav.navigate("status/$taskId") },
+                onHistoryClick = { taskId -> nav.navigate("status/$taskId") }
+            )
         }
 
         /** 界面 2 —— 轮询任务 **/

--- a/app/src/main/java/com/example/client_volcal_baseline/ui/upload/UploadScreen.kt
+++ b/app/src/main/java/com/example/client_volcal_baseline/ui/upload/UploadScreen.kt
@@ -18,6 +18,8 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import java.text.DecimalFormat
+import java.text.SimpleDateFormat
+import java.util.Locale
 
 @Composable
 fun UploadScreen(
@@ -29,6 +31,7 @@ fun UploadScreen(
     val progress by vm.progress.collectAsStateWithLifecycle()
     val ready by vm.ready.collectAsStateWithLifecycle()
     val tasks by vm.tasks.collectAsStateWithLifecycle()
+    val timeFormat = remember { SimpleDateFormat("yyyy-MM-dd HH:mm", Locale.getDefault()) }
     val ctx = LocalContext.current
     val df = remember { DecimalFormat("#,##0.# KB") }
 
@@ -90,14 +93,19 @@ fun UploadScreen(
                     .fillMaxWidth()
                     .heightIn(max = 240.dp)
             ) {
-                items(tasks) { id ->
-                    Text(
-                        text = id,
-                        modifier = Modifier
+                items(tasks) { entry ->
+                    Row(
+                        Modifier
                             .fillMaxWidth()
-                            .clickable { onHistoryClick(id) }
-                            .padding(vertical = 8.dp)
-                    )
+                            .clickable { onHistoryClick(entry.id) }
+                            .padding(vertical = 8.dp),
+                        horizontalArrangement = Arrangement.SpaceBetween
+                    ) {
+                        Text(entry.id)
+                        if (entry.time > 0) {
+                            Text(timeFormat.format(java.util.Date(entry.time)))
+                        }
+                    }
                     Divider()
                 }
             }

--- a/app/src/main/java/com/example/client_volcal_baseline/ui/upload/UploadScreen.kt
+++ b/app/src/main/java/com/example/client_volcal_baseline/ui/upload/UploadScreen.kt
@@ -7,6 +7,8 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.clickable
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
@@ -20,11 +22,13 @@ import java.text.DecimalFormat
 @Composable
 fun UploadScreen(
     vm: UploadViewModel,
-    onNavigate: (String) -> Unit
+    onNavigate: (String) -> Unit,
+    onHistoryClick: (String) -> Unit = onNavigate
 ) {
     val slots by vm.slots.collectAsStateWithLifecycle()
     val progress by vm.progress.collectAsStateWithLifecycle()
     val ready by vm.ready.collectAsStateWithLifecycle()
+    val tasks by vm.tasks.collectAsStateWithLifecycle()
     val ctx = LocalContext.current
     val df = remember { DecimalFormat("#,##0.# KB") }
 
@@ -77,6 +81,26 @@ fun UploadScreen(
                 enabled = ready,
                 modifier = Modifier.fillMaxWidth()
             ) { Text("Next") }
+
+            Spacer(Modifier.height(16.dp))
+            Text("Previous Tasks", style = MaterialTheme.typography.titleMedium)
+
+            LazyColumn(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .heightIn(max = 240.dp)
+            ) {
+                items(tasks) { id ->
+                    Text(
+                        text = id,
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .clickable { onHistoryClick(id) }
+                            .padding(vertical = 8.dp)
+                    )
+                    Divider()
+                }
+            }
         }
 
         progress?.let {

--- a/app/src/main/java/com/example/client_volcal_baseline/ui/upload/UploadScreen.kt
+++ b/app/src/main/java/com/example/client_volcal_baseline/ui/upload/UploadScreen.kt
@@ -94,12 +94,11 @@ fun UploadScreen(
                     .heightIn(max = 240.dp)
             ) {
                 items(tasks) { entry ->
-                    Row(
+                    Column(
                         Modifier
                             .fillMaxWidth()
                             .clickable { onHistoryClick(entry.id) }
-                            .padding(vertical = 8.dp),
-                        horizontalArrangement = Arrangement.SpaceBetween
+                            .padding(vertical = 8.dp)
                     ) {
                         Text(entry.id)
                         if (entry.time > 0) {

--- a/app/src/main/java/com/example/client_volcal_baseline/ui/upload/UploadViewModel.kt
+++ b/app/src/main/java/com/example/client_volcal_baseline/ui/upload/UploadViewModel.kt
@@ -8,6 +8,7 @@ import androidx.lifecycle.ViewModelProvider
 import com.example.client_volcal_baseline.network.RetrofitProvider
 import com.example.client_volcal_baseline.util.copyToTemp
 import com.example.client_volcal_baseline.util.displayName
+import com.example.client_volcal_baseline.util.TaskHistory
 import io.tus.android.client.TusPreferencesURLStore
 import io.tus.java.client.TusClient
 import io.tus.java.client.TusUpload
@@ -38,6 +39,9 @@ class UploadViewModel(private val ctx: Context) : ViewModel() {
     private val _progress = MutableStateFlow<Float?>(null)
     val progress: StateFlow<Float?> = _progress.asStateFlow()
 
+    private val _tasks = MutableStateFlow(TaskHistory.getAll(ctx))
+    val tasks: StateFlow<List<String>> = _tasks.asStateFlow()
+
     val ready: StateFlow<Boolean> = combine(slots, progress) { s, p ->
         s.all { it.uri != null } && p == null
     }.stateIn(viewModelScope, SharingStarted.Eagerly, false)
@@ -46,6 +50,11 @@ class UploadViewModel(private val ctx: Context) : ViewModel() {
         _slots.update { list ->
             list.toMutableList().also { it[index] = it[index].copy(uri = uri, size = size) }
         }
+    }
+
+    private fun addTask(id: String) {
+        TaskHistory.add(ctx, id)
+        _tasks.value = TaskHistory.getAll(ctx)
     }
 
     private suspend fun uploadOne(uri: Uri, slotIdx: Int, url: String) =
@@ -89,6 +98,7 @@ class UploadViewModel(private val ctx: Context) : ViewModel() {
                 _progress.value = null
 //                RetrofitProvider.api.startTask(createRes.task_id)
                 println(createRes.task_id)
+                addTask(createRes.task_id)
                 onDone(createRes.task_id)
             } catch (e: Exception) {
                 _progress.value = null

--- a/app/src/main/java/com/example/client_volcal_baseline/ui/upload/UploadViewModel.kt
+++ b/app/src/main/java/com/example/client_volcal_baseline/ui/upload/UploadViewModel.kt
@@ -9,6 +9,7 @@ import com.example.client_volcal_baseline.network.RetrofitProvider
 import com.example.client_volcal_baseline.util.copyToTemp
 import com.example.client_volcal_baseline.util.displayName
 import com.example.client_volcal_baseline.util.TaskHistory
+import com.example.client_volcal_baseline.util.TaskEntry
 import io.tus.android.client.TusPreferencesURLStore
 import io.tus.java.client.TusClient
 import io.tus.java.client.TusUpload
@@ -40,7 +41,7 @@ class UploadViewModel(private val ctx: Context) : ViewModel() {
     val progress: StateFlow<Float?> = _progress.asStateFlow()
 
     private val _tasks = MutableStateFlow(TaskHistory.getAll(ctx))
-    val tasks: StateFlow<List<String>> = _tasks.asStateFlow()
+    val tasks: StateFlow<List<TaskEntry>> = _tasks.asStateFlow()
 
     val ready: StateFlow<Boolean> = combine(slots, progress) { s, p ->
         s.all { it.uri != null } && p == null

--- a/app/src/main/java/com/example/client_volcal_baseline/util/TaskHistory.kt
+++ b/app/src/main/java/com/example/client_volcal_baseline/util/TaskHistory.kt
@@ -1,0 +1,25 @@
+package com.example.client_volcal_baseline.util
+
+import android.content.Context
+import org.json.JSONArray
+
+object TaskHistory {
+    private const val PREFS = "task_history"
+    private const val KEY = "ids"
+
+    fun getAll(ctx: Context): List<String> {
+        val pref = ctx.getSharedPreferences(PREFS, 0)
+        val json = pref.getString(KEY, "[]")
+        val arr = JSONArray(json)
+        return List(arr.length()) { idx -> arr.getString(idx) }
+    }
+
+    fun add(ctx: Context, id: String) {
+        val list = getAll(ctx).toMutableList()
+        if (!list.contains(id)) list.add(0, id)
+        val arr = JSONArray()
+        list.forEach { arr.put(it) }
+        val pref = ctx.getSharedPreferences(PREFS, 0)
+        pref.edit().putString(KEY, arr.toString()).apply()
+    }
+}

--- a/app/src/main/java/com/example/client_volcal_baseline/util/TaskHistory.kt
+++ b/app/src/main/java/com/example/client_volcal_baseline/util/TaskHistory.kt
@@ -2,23 +2,47 @@ package com.example.client_volcal_baseline.util
 
 import android.content.Context
 import org.json.JSONArray
+import org.json.JSONObject
+
+data class TaskEntry(val id: String, val time: Long)
 
 object TaskHistory {
     private const val PREFS = "task_history"
     private const val KEY = "ids"
 
-    fun getAll(ctx: Context): List<String> {
+    fun getAll(ctx: Context): List<TaskEntry> {
         val pref = ctx.getSharedPreferences(PREFS, 0)
         val json = pref.getString(KEY, "[]")
         val arr = JSONArray(json)
-        return List(arr.length()) { idx -> arr.getString(idx) }
+        val list = mutableListOf<TaskEntry>()
+        for (i in 0 until arr.length()) {
+            val obj = arr.optJSONObject(i)
+            if (obj != null) {
+                val id = obj.optString("id")
+                val time = obj.optLong("time")
+                if (id.isNotEmpty()) list.add(TaskEntry(id, time))
+            } else {
+                val id = arr.optString(i)
+                if (id.isNotEmpty()) list.add(TaskEntry(id, 0L))
+            }
+        }
+        return list.sortedBy { it.time }
     }
 
     fun add(ctx: Context, id: String) {
-        val list = getAll(ctx).toMutableList()
-        if (!list.contains(id)) list.add(0, id)
+        val list = getAll(ctx).filter { it.id != id }.toMutableList()
+        list.add(TaskEntry(id, System.currentTimeMillis()))
+        save(ctx, list)
+    }
+
+    private fun save(ctx: Context, list: List<TaskEntry>) {
         val arr = JSONArray()
-        list.forEach { arr.put(it) }
+        list.sortedBy { it.time }.forEach {
+            val obj = JSONObject()
+            obj.put("id", it.id)
+            obj.put("time", it.time)
+            arr.put(obj)
+        }
         val pref = ctx.getSharedPreferences(PREFS, 0)
         pref.edit().putString(KEY, arr.toString()).apply()
     }


### PR DESCRIPTION
## Summary
- keep list of task IDs in `TaskHistory`
- expose history from `UploadViewModel`
- show previous tasks on `UploadScreen`
- navigate to status screen when clicking a task

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_688432b72de08328bab07a345fbe5038